### PR TITLE
Add/gp get untranslated langs endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/gp-translation-extended-api/gp-translation-extended-api.php
+++ b/gp-translation-extended-api/gp-translation-extended-api.php
@@ -17,6 +17,11 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 		$this->tmpl( 'status-ok' );
 	}
 
+	/**
+	 * Gets translation set by project and locale slug, and returns counts and
+	 * an array of untranslated strings (up to the number defined in GP::$translation->per_page)
+	 *
+	 */
 	function translation_get_untranslated_language() {
 		if ( ! $this->api ) {
 			$this->die_with_error( __( "Yer not 'spose ta be here." ), 403 );
@@ -40,27 +45,24 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 		$page = 1;
 		$locale = GP_Locales::by_slug( $locale_slug );
 
-		GP::$translation->per_page = 5;
-
-
 		$project = GP::$project->by_path( $project_path );
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
 		$translations = GP::$translation->for_translation( $project, $translation_set, $page, $filters, $sort );
 
 		$result = new stdClass();
-		$result->all_count 			= $translation_set->all_count();
-		$result->country_code 		= $locale->country_code;
-		$result->current_count 		= $translation_set->current_count();
-		$result->fuzzy_count 		= $translation_set->fuzzy_count();
-		$result->language_name 		= $locale->native_name;
-		$result->language_name_en 	= $locale->english_name;
-		$result->last_modified 		= $translation_set->current_count ? $translation_set->last_modified() : false;
-		$result->percent_translated = $translation_set->percent_translated();
-		$result->slug 				= $locale->slug;
-		$result->translations 		= $translations;
-		$result->untranslated_count = $translation_set->untranslated_count();
-		$result->waiting_count 		= $translation_set->waiting_count();
-		$result->wp_locale			= $locale->wp_locale;
+		$result->all_count 					= $translation_set->all_count();
+		$result->country_code 				= $locale->country_code;
+		$result->current_count 				= $translation_set->current_count();
+		$result->fuzzy_count 				= $translation_set->fuzzy_count();
+		$result->language_name 				= $locale->native_name;
+		$result->language_name_en 			= $locale->english_name;
+		$result->last_modified 				= $translation_set->current_count ? $translation_set->last_modified() : false;
+		$result->percent_translated 		= $translation_set->percent_translated();
+		$result->slug 						= $locale->slug;
+		$result->untranslated_strings		= $translations;
+		$result->untranslated_count 		= $translation_set->untranslated_count();
+		$result->waiting_count 				= $translation_set->waiting_count();
+		$result->wp_locale					= $locale->wp_locale;
 
 		$translations = $result;
 		$this->tmpl( 'translations-extended', get_defined_vars(), true );

--- a/gp-translation-extended-api/gp-translation-extended-api.php
+++ b/gp-translation-extended-api/gp-translation-extended-api.php
@@ -20,6 +20,7 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 	/**
 	 * Gets translation set by project and locale slug, and returns counts and
 	 * an array of untranslated strings (up to the number defined in GP::$translation->per_page)
+	 * Example GET string: https://translate.wordpress.com/api/translations/-untranslated-by-locale?translation_set_slug=default&locale_slug=ta&project=wpcom&view=calypso
 	 *
 	 */
 	function translations_get_untranslated_strings_by_locale() {
@@ -29,6 +30,7 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 
 		$project_path          	= gp_get( 'project' );
 		$locale_slug           	= gp_get( 'locale_slug' );
+		$project_view           = gp_get( 'view', null );
 		$translation_set_slug  	= gp_get( 'translation_set_slug', 'default' );
 
 		if ( ! $project_path || ! $locale_slug || ! $translation_set_slug ) {
@@ -36,8 +38,9 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 		}
 
 		$filters = array(
-			'status' => 'untranslated'
+			'status' 	=> 'untranslated',
 		);
+
 		$sort = array(
 			'by' => 'priority',
 			'how' => 'desc',
@@ -48,6 +51,11 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 		$project = GP::$project->by_path( $project_path );
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
 		$translations = GP::$translation->for_translation( $project, $translation_set, $page, $filters, $sort );
+
+		if ( $project_view && class_exists( 'GP_Views' ) ) {
+			$gp_plugin_views = GP_Views::get_instance();
+			$gp_plugin_views->set_project_id( $project->id );
+		}
 
 		$result = new stdClass();
 		$result->all_count 					= $translation_set->all_count();
@@ -348,3 +356,4 @@ class GP_Translation_Extended_API_Loader {
 
 $gp_translation_extended_api = new GP_Translation_Extended_API_Loader();
 add_action( 'gp_init', array( $gp_translation_extended_api, 'init' ) );
+

--- a/gp-translation-extended-api/gp-translation-extended-api.php
+++ b/gp-translation-extended-api/gp-translation-extended-api.php
@@ -22,7 +22,7 @@ class GP_Route_Translation_Extended extends GP_Route_Main {
 	 * an array of untranslated strings (up to the number defined in GP::$translation->per_page)
 	 *
 	 */
-	function translation_get_untranslated_language() {
+	function translations_get_untranslated_strings_by_locale() {
 		if ( ! $this->api ) {
 			$this->die_with_error( __( "Yer not 'spose ta be here." ), 403 );
 		}
@@ -341,8 +341,8 @@ class GP_Translation_Extended_API_Loader {
 		GP::$router->add( '/translations/(\d+)/-set-status', array( 'GP_Route_Translation_Extended', 'translations_options_ok' ), 'options' );
 		GP::$router->add( '/translations/-query-by-originals', array( 'GP_Route_Translation_Extended', 'translations_get_by_originals' ), 'post' );
 		GP::$router->add( '/translations/-query-by-originals', array( 'GP_Route_Translation_Extended', 'translations_options_ok' ), 'options' );
-		GP::$router->add( '/translations/-translation-set', array( 'GP_Route_Translation_Extended', 'translation_get_untranslated_language' ), 'get' );
-		GP::$router->add( '/translations/-translation-set', array( 'GP_Route_Translation_Extended', 'translations_options_ok' ), 'options' );
+		GP::$router->add( '/translations/-untranslated-by-locale', array( 'GP_Route_Translation_Extended', 'translations_get_untranslated_strings_by_locale' ), 'get' );
+		GP::$router->add( '/translations/-untranslated-by-locale', array( 'GP_Route_Translation_Extended', 'translations_get_untranslated_strings_by_locale' ), 'options' );
 	}
 }
 


### PR DESCRIPTION
The idea behind this PR is to provide a resource to Calypso or another client, to get a quick overview of the status of a `translation_set`, more specifically how 'translated' it is.

If there are strings waiting to be translated, we provide the first 15 sorted by priority. 

## What's it for?
The end goal is to have a popup module to ask a user of a language if he or she would like to assist with the untranslated strings. Adding a translation can be done quickly inline.

There is a risk in that the translation provide no context to the user. Similarly, that the user won't provide quality translations. We have to balance this risk with our desire to address languages with high untranslated counts.

## Existing endpoints
We can already get much of this information via the existing GP API:

**Translation sets and counts (all):**
https://translate.wordpress.com/api/projects/wpcom

**Untranslated strings for a locale (ta)**
https://translate.wordpress.com/api/translations/-untranslated-by-locale?translation_set_slug=default&locale_slug=ta&project=wpcom&view=calypso

Both this endpoints return more data than we need, and therefore present a little more work for the client. I'm open to just using the above endpoints if it's more appropriate however.

Below is the output:

```
{
    "all_count": 22486,
    "country_code": "in",
    "current_count": 4831,
    "fuzzy_count": 6,
    "language_name": "தமிழ்",
    "language_name_en": "Tamil",
    "last_modified": "2018-01-07 10:01:20",
    "percent_translated": 21,
    "slug": "ta",
    "untranslated_strings": [
        {
            "is_plural": false,
            "context": null,
            "singular": "Advanced customization",
            "plural": null,
            "translations": [
                null,
                null
            ],
            "translator_comments": "",
            "extracted_comments": "",
            "references": [
                "client/lib/plans/constants.js:740"
            ],
            "flags": [],
            "id": null,
            "original_id": "58054",
            "translation_set_id": null,
            "user_id": null,
            "status": "+active",
            "date_added": "2012-12-26 12:00:53",
            "date_modified": null,
            "warnings": null,
            "user_id_last_modified": null,
            "project_id": "1",
            "priority": "1",
            "translation_status": null,
            "original_status": "+active",
            "translation_added": null,
            "original_added": "2012-12-26 12:00:53",
            "user_last_modified": null,
            "user": null,
            "row_id": "58054"
        },
    ],
    "untranslated_count": 17655,
    "waiting_count": 181,
    "wp_locale": "ta_IN"
}

```
  